### PR TITLE
Added passPercentage property

### DIFF
--- a/scripts/single-choice-set.js
+++ b/scripts/single-choice-set.js
@@ -16,6 +16,7 @@ H5P.SingleChoiceSet = (function ($, UI, Question, SingleChoice, SolutionView, Re
     Question.call(this, 'single-choice-set');
     this.options = $.extend(true, {}, {
       choices: [],
+      passPercentage: 100,
       behaviour: {
         timeoutCorrect: 2000,
         timeoutWrong: 3000,
@@ -346,7 +347,7 @@ H5P.SingleChoiceSet = (function ($, UI, Question, SingleChoice, SolutionView, Re
           .replace(':maxscore', self.options.choices.length.toString()),
         score, self.options.choices.length);
 
-      if (score === self.options.choices.length) {
+      if ((100 * score / self.options.choices.length) >= self.options.passPercentage) {
         self.hideButton('try-again');
         self.hideButton('show-solution');
       }

--- a/semantics.json
+++ b/semantics.json
@@ -39,6 +39,16 @@
     }
   },
   {
+    "name": "passPercentage",
+    "type": "number",
+    "label": "Pass percentage",
+    "description": "Percentage of Total score required for passing the quiz.",
+    "min": 0,
+    "max": 100,
+    "step": 1,
+    "default": 100
+  },
+  {
     "name": "behaviour",
     "type": "group",
     "label": "Behavioural settings",


### PR DESCRIPTION
Added "passPercentage" property. This allows flexible customizing the question set.
E.g. when 75 of 100% correct answers enough to show the success feedback.