### PR TITLE
Don't report score for empty questions

### DIFF
--- a/presave.js
+++ b/presave.js
@@ -15,7 +15,11 @@ H5PPresave['H5P.SingleChoiceSet'] = function (content, finished) {
     throw new presave.exceptions.InvalidContentSemanticsException('Invalid Single Choice Error');
   }
 
-  score = content.choices.length;
+  score = content.choices
+    .filter(function (choice) {
+      return choice.hasOwnProperty('question') && choice.question.length > 0;
+    })
+    .length;
 
   presave.validateScore(score);
 


### PR DESCRIPTION
Fixed bug where an empty question is reported as a point when calculating the max score.