### PR TITLE
Stop giving away correct answers in page source

### DIFF
--- a/scripts/single-choice-alternative.js
+++ b/scripts/single-choice-alternative.js
@@ -25,7 +25,7 @@ H5P.SingleChoiceSet.Alternative = (function ($, EventDispatcher) {
     };
 
     this.$alternative = $('<li>', {
-      'class': 'h5p-sc-alternative h5p-sc-is-' + (this.options.correct ? 'correct' : 'wrong'),
+      'class': 'h5p-sc-alternative',
       'role': 'button',
       'tabindex': -1,
       'on': {

--- a/scripts/single-choice-set.js
+++ b/scripts/single-choice-set.js
@@ -790,7 +790,7 @@ H5P.SingleChoiceSet = (function ($, UI, Question, SingleChoice, SolutionView, Re
     this.solutionView.hide();
 
     // Reset the user's answers
-    var classes = ['h5p-sc-reveal-wrong', 'h5p-sc-reveal-correct', 'h5p-sc-selected', 'h5p-sc-drummed', 'h5p-sc-correct-answer'];
+    var classes = ['h5p-sc-reveal-wrong', 'h5p-sc-reveal-correct', 'h5p-sc-selected', 'h5p-sc-drummed', 'h5p-sc-correct-answer', 'h5p-sc-is-correct', 'h5p-sc-is-wrong'];
     for (var i = 0; i < classes.length; i++) {
       this.$choices.find('.' + classes[i]).removeClass(classes[i]);
     }

--- a/scripts/single-choice.js
+++ b/scripts/single-choice.js
@@ -211,7 +211,10 @@ H5P.SingleChoiceSet.SingleChoice = (function ($, EventDispatcher, Alternative) {
   SingleChoice.prototype.showResult = function (correct, answerIndex) {
     var self = this;
 
-    var $correctAlternative = self.$choice.find('.h5p-sc-is-correct');
+    const $correctAlternative = self.alternatives.filter(function (alternative) {
+      return alternative.options.correct;
+    })[0].$alternative;
+    $correctAlternative.addClass('h5p-sc-is-correct');
 
     H5P.Transition.onTransitionEnd($correctAlternative, function () {
       self.trigger('finished', {
@@ -222,7 +225,15 @@ H5P.SingleChoiceSet.SingleChoice = (function ($, EventDispatcher, Alternative) {
     }, 600);
 
     // Reveal corrects and wrong
-    self.$choice.find('.h5p-sc-is-wrong').addClass('h5p-sc-reveal-wrong');
+    const wrongAlternatives = self.alternatives
+      .filter(function (alternative) {
+        return !alternative.options.correct;
+      })
+      .forEach(function (alternative) {
+        alternative.$alternative.addClass('h5p-sc-reveal-wrong');
+        alternative.$alternative.addClass('h5p-sc-is-wrong');
+      });
+
     $correctAlternative.addClass('h5p-sc-reveal-correct');
   };
 


### PR DESCRIPTION
In its current implementation, Single Choice Set uses CSS classes to determine which answer is correct and which are wrong. This, of course, allows very easy cheating, cmp. https://www.instagram.com/p/CCBSRl7izWw/ While you can never rule out cheating with client site evaluation, let's make it a little harder at least :-)

When merged in, the changes will stop using CSS classes to determine which answer is correct and which are wrong but use the options parameter that's there anyway.