### PR TITLE
HFP-4224 Fix cursor after selection answer option

### DIFF
--- a/styles/single-choice-set.css
+++ b/styles/single-choice-set.css
@@ -90,7 +90,6 @@ ul.h5p-sc-alternatives {
 }
 ul.h5p-sc-alternatives li.h5p-sc-alternative {
   position: relative;
-  cursor: pointer;
   box-sizing: border-box;
   list-style: none;
   margin: .5em 0;
@@ -104,6 +103,10 @@ ul.h5p-sc-alternatives li.h5p-sc-alternative {
 
   transition: -webkit-transform 0.5s ease-in-out, width 0.5s ease-in-out;
   transition: transform 0.5s ease-in-out, width 0.5s ease-in-out;
+}
+
+ul.h5p-sc-alternatives:not(.h5p-sc-selected) li.h5p-sc-alternative {
+  cursor: pointer;
 }
 
 ul.h5p-sc-alternatives li.h5p-sc-alternative:hover {


### PR DESCRIPTION
When merged in, will not let the mouse cursor suggest an answer could be interacted with after an answer has been given.