### PR TITLE
VA-878 bottom spacing consistency

### DIFF
--- a/styles/single-choice-set.css
+++ b/styles/single-choice-set.css
@@ -40,7 +40,7 @@
   margin-inline: var(--h5p-theme-spacing-m);
   position: relative;
   box-sizing: border-box;
-  margin-bottom: var(--h5p-theme-spacing-xxs);
+  margin-bottom: var(--h5p-theme-spacing-m);
 }
 
 .h5p-single-choice-set .h5p-joubelui-progressbar {
@@ -68,7 +68,6 @@
   position: absolute;
   left: 0;
   top: 0;
-  padding-bottom: .5em;
 }
 
 .initialized .h5p-sc-slide {
@@ -106,6 +105,9 @@ ul.h5p-sc-alternatives li.h5p-sc-alternative {
   font-weight: 600;
   color: var(--h5p-theme-text-secondary);
   font-size: var(--h5p-theme-font-size-m);
+}
+.h5p-sc-alternatives li.h5p-sc-alternative:last-child {
+  margin-bottom: 0;
 }
 
 ul.h5p-sc-alternatives li.h5p-sc-alternative:hover {


### PR DESCRIPTION
the `h5p-sc-slide` being taller than it's content because of absolute. I wanted to avoid refactoring css related to absolute. so I added 8px margin to make it 24 in total

8px from `h5p-sc-slide` height + 8px of the padding + 8px margin

_(we can remove the padding-bottom, then `h5p-sc-slide` will be 16px so it's the same margin required)_