### PR TITLE
VA-1045 Allow author styling to prevail

### DIFF
--- a/styles/single-choice-set.css
+++ b/styles/single-choice-set.css
@@ -263,10 +263,6 @@ li.h5p-sc-alternative .h5p-sc-status {
   box-sizing: border-box;
 }
 
-.h5p-sc-set-results .h5p-theme-results-question {
-  font-weight: inherit;
-}
-
 .h5p-sc-set-results .h5p-theme-results-question p {
   margin: 0;
 }


### PR DESCRIPTION
When merged in, will override the `font-weight` styling imposed by H5P.Question/H5P.Components to not overrule the text styling choices of the author.